### PR TITLE
Todo削除機能、他画面デザインの調整

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -19,12 +19,14 @@ import {MatFormFieldModule} from '@angular/material/form-field';
 import {MatInputModule} from '@angular/material/input';
 import {MatSelectModule} from '@angular/material/select';
 import {MatSnackBarModule} from '@angular/material/snack-bar';
+import {MatDialogModule} from '@angular/material/dialog';
 
 import { TodoListComponent } from './todo/todo-list/todo-list.component';
 import { TodoEditComponent } from './todo/todo-edit/todo-edit.component';
 import { TodoAddComponent } from './todo/todo-add/todo-add.component';
 import { CardComponent } from './todo/component/card/card.component';
 import { FormComponent } from './todo/component/form/form.component';
+import { DialogComponent } from './todo/component/dialog/dialog.component';
 @NgModule({
   declarations: [
     AppComponent,
@@ -32,7 +34,8 @@ import { FormComponent } from './todo/component/form/form.component';
     TodoEditComponent,
     TodoAddComponent,
     CardComponent,
-    FormComponent
+    FormComponent,
+    DialogComponent
   ],
   imports: [
     BrowserModule,
@@ -50,7 +53,8 @@ import { FormComponent } from './todo/component/form/form.component';
     MatFormFieldModule,
     MatInputModule,
     MatSelectModule,
-    MatSnackBarModule
+    MatSnackBarModule,
+    MatDialogModule
   ],
   providers: [],
   bootstrap: [AppComponent]

--- a/src/app/todo/component/card/card.component.html
+++ b/src/app/todo/component/card/card.component.html
@@ -1,12 +1,12 @@
 <mat-card class="margin-a-20">
     <a class="card-link" [routerLink]="['/todo/show', item.id ]"></a>
     <mat-card-header>
-        <span class="category"><mat-card-title>{{item.categoryId}}</mat-card-title></span>
-        <span><mat-card-title>{{item.title}}</mat-card-title></span>
+        <span class="category"><mat-card-title>{{item.id}}</mat-card-title></span>
+        <span><mat-card-title>{{item.categoryId}} {{item.title}}</mat-card-title></span>
         <span class="spacer"></span> 
         <span>
-            <mat-card-subtitle>{{item.createdAt}}</mat-card-subtitle>
-            <mat-card-subtitle>{{item.updatedAt}}</mat-card-subtitle>
+            <mat-card-subtitle>{{getLocalTime(item.createdAt)}}</mat-card-subtitle>
+            <mat-card-subtitle>{{getLocalTime(item.updatedAt)}}</mat-card-subtitle>
         </span>
     </mat-card-header>
     <mat-card-content>

--- a/src/app/todo/component/card/card.component.ts
+++ b/src/app/todo/component/card/card.component.ts
@@ -23,7 +23,8 @@ export class CardComponent {
   }
   getLocalTime(timeStr?:string){
     if(typeof timeStr === 'string'){
-      return new Date(timeStr).toLocaleDateString() +' '+ new Date(timeStr).toLocaleTimeString()
+      let date = new Date(timeStr)
+      return date.toLocaleDateString() +' '+ date.toLocaleTimeString()
     }else{
       return ''
     }

--- a/src/app/todo/component/card/card.component.ts
+++ b/src/app/todo/component/card/card.component.ts
@@ -21,4 +21,11 @@ export class CardComponent {
   getBrEscape(text:string){
     return text.replace(/\\r\\n/g, '\r\n');
   }
+  getLocalTime(timeStr?:string){
+    if(typeof timeStr === 'string'){
+      return new Date(timeStr).toLocaleDateString() +' '+ new Date(timeStr).toLocaleTimeString()
+    }else{
+      return ''
+    }
+  }
 }

--- a/src/app/todo/component/dialog/dialog.component.html
+++ b/src/app/todo/component/dialog/dialog.component.html
@@ -1,0 +1,8 @@
+<h1 mat-dialog-title>削除</h1>
+<div mat-dialog-content>
+  <p>削除してもいいですか？</p>
+</div>
+<div mat-dialog-actions>
+  <button class="float-left" mat-raised-button [mat-dialog-close]="false">戻る</button>
+  <button class="float-right" mat-raised-button color="warn"  cdkFocusInitial [mat-dialog-close]="true">削除</button>
+</div>

--- a/src/app/todo/component/dialog/dialog.component.scss
+++ b/src/app/todo/component/dialog/dialog.component.scss
@@ -1,0 +1,6 @@
+.float-left{
+    float: left;
+}
+.float-right{
+    float: right;
+}

--- a/src/app/todo/component/dialog/dialog.component.ts
+++ b/src/app/todo/component/dialog/dialog.component.ts
@@ -1,0 +1,12 @@
+import { Component, Inject} from '@angular/core';
+import { MatDialogRef} from '@angular/material/dialog';
+@Component({
+  selector: 'dialog-overview-example-dialog',
+  templateUrl: './dialog.component.html',
+  styleUrls: ['./dialog.component.scss']
+})
+export class DialogComponent {
+  constructor(
+    public dialogRef: MatDialogRef<DialogComponent>,
+  ) {}
+}

--- a/src/app/todo/component/form/form.component.html
+++ b/src/app/todo/component/form/form.component.html
@@ -40,7 +40,13 @@
         </form>
     </mat-card-content>
     <mat-card-footer>
-      <button *ngIf="!notAddPage" mat-raised-button color="primary" class="margin-a-20" (click)="onAddButtonClick()" [disabled]="todoForm.invalid">登録</button>
-      <button *ngIf="notAddPage" mat-raised-button color="primary" class="margin-a-20" (click)="onUpdateButtonClick()" [disabled]="todoForm.invalid">更新</button>
+      <span class="float-left">
+        <button mat-raised-button color="warn" class="margin-a-20" (click)="onDeleteButtonClick()" >削除</button>
+      </span> 
+      <span> </span>
+      <span class="float-right">
+        <button *ngIf="!notAddPage" mat-raised-button color="primary" class="margin-a-20" (click)="onAddButtonClick()" [disabled]="todoForm.invalid">登録</button>
+        <button *ngIf="notAddPage" mat-raised-button color="primary" class="margin-a-20" (click)="onUpdateButtonClick()" [disabled]="todoForm.invalid">更新</button>
+      </span> 
     </mat-card-footer>
 </mat-card>

--- a/src/app/todo/component/form/form.component.scss
+++ b/src/app/todo/component/form/form.component.scss
@@ -11,3 +11,9 @@
 .textarea-full-width {
     width: 100%;
 }
+.float-left{
+    float: left;
+}
+.float-right{
+    float: right;
+}

--- a/src/app/todo/component/form/form.component.ts
+++ b/src/app/todo/component/form/form.component.ts
@@ -1,10 +1,12 @@
-import { Component,} from '@angular/core';
+import { Component,Inject} from '@angular/core';
 import { FormControl, FormGroup,Validators } from '@angular/forms';
 import { ActivatedRoute,Router } from '@angular/router';
 import { TodoService } from '../../service/todo.service';
 import { Todo } from '../../../models/todo';
 import { Message } from '../../../models/message';
 import { MatSnackBar } from '@angular/material/snack-bar';
+import { MatDialog, MAT_DIALOG_DATA, MatDialogRef} from '@angular/material/dialog';
+import { DialogComponent} from '../dialog/dialog.component';
 @Component({
   selector: 'todo-form',
   templateUrl: './form.component.html',
@@ -22,6 +24,7 @@ export class FormComponent {
    */
   constructor(
     private snackBar: MatSnackBar,
+    private dialog: MatDialog,
     private route: ActivatedRoute,
     private router: Router,
     private todoService: TodoService
@@ -65,6 +68,24 @@ export class FormComponent {
     let todo:Todo = this.todoForm.value
     this.editTodo(this.id, todo)
     console.log(todo)
+  }
+  /**
+   * 削除ボタンクリック
+   */
+  onDeleteButtonClick(){
+    const dialogRef = this.dialog.open(DialogComponent, {
+      data:false
+    });
+    dialogRef.afterClosed().subscribe(result => {
+      if(result){
+        this.todoService.deleteTodo(this.id).subscribe((data)=>{
+          this.snackBar.open(data.message, "OK", {
+            duration: 2000
+          });
+          this.router.navigate(['/todo']);
+        })
+      }
+    });
   }
   /**
    * Todoデータ取得処理

--- a/src/app/todo/service/todo.service.ts
+++ b/src/app/todo/service/todo.service.ts
@@ -27,11 +27,11 @@ export class TodoService {
 
   addTodo(Todo: Todo): Observable<Message> {
     const newTodo: Todo = {
-      id:    Todo.id,
-      categoryId: Todo.categoryId,
+      id:    Number(Todo.id),
+      categoryId: Number(Todo.categoryId),
       title: Todo.title,
       body: Todo.body,
-      state: Todo.state,
+      state: Number(Todo.state),
     }
     return this.http.post<Message>(this.Url, newTodo, this.httpOptions)
 
@@ -40,11 +40,11 @@ export class TodoService {
   editTodo(id:number, Todo: Todo): Observable<Message> {
     const url = `${this.Url}/${id}`
     const editTodo: Todo = {
-        id:    Todo.id,
-        categoryId: Todo.categoryId,
+        id:    Number(Todo.id),
+        categoryId: Number(Todo.categoryId),
         title: Todo.title,
         body: Todo.body,
-        state: Todo.state,
+        state: Number(Todo.state),
     }
     return this.http.put<Message>(url, editTodo, this.httpOptions)
   }

--- a/src/app/todo/service/todo.service.ts
+++ b/src/app/todo/service/todo.service.ts
@@ -27,11 +27,11 @@ export class TodoService {
 
   addTodo(Todo: Todo): Observable<Message> {
     const newTodo: Todo = {
-      id:    Number(Todo.id),
-      categoryId: Number(Todo.categoryId),
+      id:    Todo.id,
+      categoryId: Todo.categoryId,
       title: Todo.title,
       body: Todo.body,
-      state: Number(Todo.state),
+      state: Todo.state,
     }
     return this.http.post<Message>(this.Url, newTodo, this.httpOptions)
 
@@ -40,11 +40,11 @@ export class TodoService {
   editTodo(id:number, Todo: Todo): Observable<Message> {
     const url = `${this.Url}/${id}`
     const editTodo: Todo = {
-        id:    Number(Todo.id),
-        categoryId: Number(Todo.categoryId),
+        id:    Todo.id,
+        categoryId: Todo.categoryId,
         title: Todo.title,
         body: Todo.body,
-        state: Number(Todo.state),
+        state: Todo.state,
     }
     return this.http.put<Message>(url, editTodo, this.httpOptions)
   }

--- a/src/app/todo/todo-add/todo-add.component.html
+++ b/src/app/todo/todo-add/todo-add.component.html
@@ -1,4 +1,7 @@
 <mat-toolbar class="margin-a-20" style="width:auto;">
+    <a mat-icon-button routerLink="/todo">
+        <mat-icon>arrow_back_ios_new</mat-icon>
+    </a>
     <span>Todo追加</span>
 </mat-toolbar>
 <todo-form></todo-form>

--- a/src/app/todo/todo-edit/todo-edit.component.html
+++ b/src/app/todo/todo-edit/todo-edit.component.html
@@ -1,4 +1,7 @@
 <mat-toolbar class="margin-a-20" style="width:auto;">
+    <a mat-icon-button routerLink="/todo">
+        <mat-icon>arrow_back_ios_new</mat-icon>
+    </a>
     <span>Todo編集</span>
     <span class="spacer"></span> 
     <a mat-flat-button color="primary" routerLink="/todo/add">Todo追加</a>

--- a/src/app/todo/todo-list/todo-list.component.html
+++ b/src/app/todo/todo-list/todo-list.component.html
@@ -1,6 +1,6 @@
 <mat-toolbar class="margin-a-20" style="width:auto;">
     <span>Todo一覧</span>
     <span class="spacer"></span> 
-    <a mat-flat-button color="primary" routerLink="/todo/add">Todo追加</a>
+    <a mat-flat-button color="primary" routerLink="/todo/add"><mat-icon>add_task</mat-icon>Todo追加</a>
 </mat-toolbar>
 <todo-card *ngFor="let todo of todoList" [item]="todo"></todo-card>


### PR DESCRIPTION
# 対応

- [削除機能実装、削除確認ダイアログを追加](https://github.com/MasayaToda/todo-front-app/commit/ee9542695042d3b84a0cb73c9c93070ef06965af)
  - 削除機能の実装と、削除ボタンクリック時に、確認ダイアログを出す機能を追加
- [削除機能実装、削除確認ダイアログを追加](https://github.com/MasayaToda/todo-front-app/commit/ee9542695042d3b84a0cb73c9c93070ef06965af)
  - ブラウザバックではなく、画面項目として、戻る遷移をサポート、Material Iconを追加
- [ApiのJsonModel修正に伴って、リクエストの数値型を修正](https://github.com/MasayaToda/todo-front-app/commit/e9d114086ebf590275f176b7e1b6ee1a72f66701)
  - サーバーサイドのバリデーションの改修に伴い、リクエスト時の数値パラメータの型を修正

# イメージ

## Todo一覧

![image](https://user-images.githubusercontent.com/117155914/203924212-9222f91a-4a8e-4efc-aeee-5f935c2799e4.png)

## Todo追加

![image](https://user-images.githubusercontent.com/117155914/203924326-d4cba188-acb2-45c7-b7ac-13e815620d0e.png)

## Todo更新

![image](https://user-images.githubusercontent.com/117155914/203924427-0272e5b9-57d3-40b4-9fba-44de697ae795.png)


## Todo削除

![image](https://user-images.githubusercontent.com/117155914/203924552-aea954a6-c4b6-48c5-a413-219f222d9bdc.png)
