### PR TITLE
カテゴリ登録/更新/削除機能を実装、他デザインの調整、表示バグ対応

### DIFF
--- a/src/app/animation.ts
+++ b/src/app/animation.ts
@@ -45,4 +45,22 @@ import {
       ]),
       query(':enter', animateChild()),
     ]),
+    transition('Page3 => Page3, Page2 => Page2, Page1 => Page1', [
+      style({ position: 'relative' }),
+      query(':enter, :leave', [
+        style({
+          position: 'absolute',
+          top: 0,
+          left: 0,
+          width: '100%',
+        }),
+      ]),
+      query(':enter', [style({ bottom: '-100%' })]),
+      query(':leave', animateChild()),
+      group([
+        query(':leave', [animate('300ms ease-out', style({ bottom: '100%' }))]),
+        query(':enter', [animate('300ms ease-out', style({ bottom: '0%' }))]),
+      ]),
+      query(':enter', animateChild()),
+    ]),
   ]);

--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -4,6 +4,8 @@ import { TodoListComponent } from './todo/todo-list/todo-list.component';
 import { TodoAddComponent } from './todo/todo-add/todo-add.component';
 import { TodoEditComponent } from './todo/todo-edit/todo-edit.component';
 import { CategoryListComponent } from './category/category-list/category-list.component';
+import { CategoryAddComponent } from './category/category-add/category-add.component';
+import { CategoryEditComponent } from './category/category-edit/category-edit.component';
 const routes: Routes = [
   { path: '', redirectTo: 'todo', pathMatch: 'full' },
   { 
@@ -25,6 +27,16 @@ const routes: Routes = [
     path: 'category', 
     component: CategoryListComponent,
     data: { animation: 'Page2' }
+  },
+  { 
+    path: 'category/add', 
+    component: CategoryAddComponent,
+    data: { animation: 'Page3' }
+  },
+  { 
+    path: 'category/show/:id', 
+    component: CategoryEditComponent,
+    data: { animation: 'Page3' }
   },
 ];
 

--- a/src/app/app.component.scss
+++ b/src/app/app.component.scss
@@ -1,3 +1,7 @@
+@use '@angular/material' as mat;
 .spacer{
     flex : 1  1 auto;
+}
+.tool-bar{
+    @include mat.elevation(10);
 }

--- a/src/app/app.component.ts
+++ b/src/app/app.component.ts
@@ -5,11 +5,11 @@ import { slideInAnimation} from './animation'
 @Component({
   selector: 'app-root',
   template: `
-  <mat-toolbar color="primary">
+  <mat-toolbar class="tool-bar" color="primary">
     <span>My Application</span>
     <span class="spacer" > </span> 
-    <a mat-flat-button color="primary" routerLink="todo">Todo</a>
-    <a mat-flat-button color="primary" routerLink="category">Category</a>
+    <a mat-flat-button color="primary" routerLink="todo"><mat-icon>view_list</mat-icon>Todo</a>
+    <a mat-flat-button color="primary" routerLink="category"><mat-icon>groups</mat-icon>Category</a>
   </mat-toolbar>
     <div [@routeAnimations]="prepareRoute(outlet)">
       <router-outlet #outlet="outlet"></router-outlet>

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -28,6 +28,8 @@ import { TodoCardComponent } from './todo/component/card/card.component';
 import { TodoFormComponent } from './todo/component/form/form.component';
 import { DialogComponent } from './common/dialog/dialog.component';
 import { CategoryListComponent } from './category/category-list/category-list.component';
+import { CategoryAddComponent } from './category/category-add/category-add.component';
+import { CategoryEditComponent } from './category/category-edit/category-edit.component';
 import { CategoryCardComponent } from './category/component/card/card.component';
 import { CategoryFormComponent } from './category/component/form/form.component';
 @NgModule({
@@ -40,6 +42,8 @@ import { CategoryFormComponent } from './category/component/form/form.component'
     TodoFormComponent,
     DialogComponent,
     CategoryListComponent,
+    CategoryAddComponent,
+    CategoryEditComponent,
     CategoryCardComponent,
     CategoryFormComponent,
   ],

--- a/src/app/category/category-add/category-add.component.html
+++ b/src/app/category/category-add/category-add.component.html
@@ -1,4 +1,4 @@
-<mat-toolbar class="margin-a-20" style="width:auto;">
+<mat-toolbar class="margin-a-20 app-bar" style="width:auto;">
     <a mat-icon-button routerLink="/category">
         <mat-icon>arrow_back_ios_new</mat-icon>
     </a>

--- a/src/app/category/category-add/category-add.component.html
+++ b/src/app/category/category-add/category-add.component.html
@@ -1,0 +1,7 @@
+<mat-toolbar class="margin-a-20" style="width:auto;">
+    <a mat-icon-button routerLink="/category">
+        <mat-icon>arrow_back_ios_new</mat-icon>
+    </a>
+    <span>Category追加</span>
+</mat-toolbar>
+<category-form></category-form>

--- a/src/app/category/category-add/category-add.component.scss
+++ b/src/app/category/category-add/category-add.component.scss
@@ -1,0 +1,16 @@
+.margin-a-20{
+    margin: 20px;
+}
+.spacer{
+    flex : 1  1 auto;
+}
+.category{
+    margin-right: 20px;
+}
+.card-link{
+    position: absolute;
+    top: 0;
+    left: 0;
+    height:100%;
+    width: 100%;
+}

--- a/src/app/category/category-add/category-add.component.scss
+++ b/src/app/category/category-add/category-add.component.scss
@@ -1,3 +1,7 @@
+@use '@angular/material' as mat;
+.app-bar{
+    @include mat.elevation(5);
+}
 .margin-a-20{
     margin: 20px;
 }

--- a/src/app/category/category-add/category-add.component.spec.ts
+++ b/src/app/category/category-add/category-add.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CategoryAddComponent } from './category-add.component';
+
+describe('CategoryAddComponent', () => {
+  let component: CategoryAddComponent;
+  let fixture: ComponentFixture<CategoryAddComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ CategoryAddComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(CategoryAddComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/category/category-add/category-add.component.ts
+++ b/src/app/category/category-add/category-add.component.ts
@@ -1,0 +1,10 @@
+import { Component } from '@angular/core';
+
+@Component({
+  selector: 'app-category-add',
+  templateUrl: './category-add.component.html',
+  styleUrls: ['./category-add.component.scss']
+})
+export class CategoryAddComponent {
+
+}

--- a/src/app/category/category-edit/category-edit.component.html
+++ b/src/app/category/category-edit/category-edit.component.html
@@ -1,0 +1,9 @@
+<mat-toolbar class="margin-a-20" style="width:auto;">
+    <a mat-icon-button routerLink="/category">
+        <mat-icon>arrow_back_ios_new</mat-icon>
+    </a>
+    <span>Category編集</span>
+    <span class="spacer"></span> 
+    <a mat-flat-button color="primary" routerLink="/category/add"><mat-icon>add_task</mat-icon>Category追加</a>
+</mat-toolbar>
+<category-form></category-form>

--- a/src/app/category/category-edit/category-edit.component.html
+++ b/src/app/category/category-edit/category-edit.component.html
@@ -1,4 +1,4 @@
-<mat-toolbar class="margin-a-20" style="width:auto;">
+<mat-toolbar class="margin-a-20 app-bar" style="width:auto;">
     <a mat-icon-button routerLink="/category">
         <mat-icon>arrow_back_ios_new</mat-icon>
     </a>

--- a/src/app/category/category-edit/category-edit.component.scss
+++ b/src/app/category/category-edit/category-edit.component.scss
@@ -1,0 +1,16 @@
+.margin-a-20{
+    margin: 20px;
+}
+.spacer{
+    flex : 1  1 auto;
+}
+.category{
+    margin-right: 20px;
+}
+.card-link{
+    position: absolute;
+    top: 0;
+    left: 0;
+    height:100%;
+    width: 100%;
+}

--- a/src/app/category/category-edit/category-edit.component.scss
+++ b/src/app/category/category-edit/category-edit.component.scss
@@ -1,3 +1,7 @@
+@use '@angular/material' as mat;
+.app-bar{
+    @include mat.elevation(5);
+}
 .margin-a-20{
     margin: 20px;
 }

--- a/src/app/category/category-edit/category-edit.component.spec.ts
+++ b/src/app/category/category-edit/category-edit.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CategoryEditComponent } from './category-edit.component';
+
+describe('CategoryEditComponent', () => {
+  let component: CategoryEditComponent;
+  let fixture: ComponentFixture<CategoryEditComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      declarations: [ CategoryEditComponent ]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(CategoryEditComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/category/category-edit/category-edit.component.ts
+++ b/src/app/category/category-edit/category-edit.component.ts
@@ -1,0 +1,15 @@
+import { Component,Output,EventEmitter } from '@angular/core';
+
+@Component({
+  selector: 'app-category-edit',
+  templateUrl: './category-edit.component.html',
+  styleUrls: ['./category-edit.component.scss']
+})
+export class CategoryEditComponent {
+  @Output() appMessageComponent = new EventEmitter<string>();
+  constructor(
+    
+    ){
+
+    }
+}

--- a/src/app/category/category-list/category-list.component.html
+++ b/src/app/category/category-list/category-list.component.html
@@ -1,6 +1,6 @@
-<mat-toolbar class="margin-a-20" style="width:auto;">
+<mat-toolbar class="margin-a-20 app-bar" style="width:auto;">
     <span>Category一覧</span>
     <span class="spacer"></span> 
-    <a mat-flat-button color="primary" routerLink="/category/add"><mat-icon>add_task</mat-icon>Category追加</a>
+    <a mat-flat-button color="primary" routerLink="/category/add"><mat-icon>group_add</mat-icon>Category追加</a>
 </mat-toolbar>
 <category-card *ngFor="let category of categoryList" [item]="category"></category-card>

--- a/src/app/category/category-list/category-list.component.scss
+++ b/src/app/category/category-list/category-list.component.scss
@@ -1,3 +1,7 @@
+@use '@angular/material' as mat;
+.app-bar{
+    @include mat.elevation(5);
+}
 .margin-a-20{
     margin: 20px;
 }

--- a/src/app/category/component/card/card.component.html
+++ b/src/app/category/component/card/card.component.html
@@ -1,4 +1,4 @@
-<mat-card class="margin-a-20">
+<mat-card class="margin-a-20 card-form-elevation">
     <a class="card-link" [routerLink]="['/category/show', item.id ]"></a>
     <mat-card-header>
         <span class="category"><mat-card-title>{{item.id}}</mat-card-title></span>

--- a/src/app/category/component/card/card.component.html
+++ b/src/app/category/component/card/card.component.html
@@ -1,5 +1,5 @@
 <mat-card class="margin-a-20">
-    <a class="card-link" [routerLink]="['/todo/show', item.id ]"></a>
+    <a class="card-link" [routerLink]="['/category/show', item.id ]"></a>
     <mat-card-header>
         <span class="category"><mat-card-title>{{item.id}}</mat-card-title></span>
         <span class="category"><mat-card-title>{{item.name}}</mat-card-title></span>

--- a/src/app/category/component/card/card.component.scss
+++ b/src/app/category/component/card/card.component.scss
@@ -1,3 +1,7 @@
+@use '@angular/material' as mat;
+.card-form-elevation{
+    @include mat.elevation(3);
+}
 .margin-a-20{
     margin: 20px;
 }

--- a/src/app/category/component/form/form.component.html
+++ b/src/app/category/component/form/form.component.html
@@ -1,4 +1,4 @@
-<mat-card class="margin-a-20">
+<mat-card class="margin-a-20 card-form-elevation">
     <mat-card-content>
         <form [formGroup]="categoryForm" class="form-size">
             <p>
@@ -32,12 +32,12 @@
     </mat-card-content>
     <mat-card-footer>
       <span class="float-left">
-        <button mat-raised-button color="warn" class="margin-a-20" (click)="onDeleteButtonClick()" >削除</button>
+        <button mat-raised-button color="warn" class="margin-a-20" (click)="onDeleteButtonClick()" ><mat-icon>delete</mat-icon>削除</button>
       </span> 
       <span> </span>
       <span class="float-right">
-        <button *ngIf="!notAddPage" mat-raised-button color="primary" class="margin-a-20" (click)="onAddButtonClick()" [disabled]="categoryForm.invalid">登録</button>
-        <button *ngIf="notAddPage" mat-raised-button color="primary" class="margin-a-20" (click)="onUpdateButtonClick()" [disabled]="categoryForm.invalid">更新</button>
+        <button *ngIf="!notAddPage" mat-raised-button color="primary" class="margin-a-20" (click)="onAddButtonClick()" [disabled]="categoryForm.invalid"><mat-icon>group_add</mat-icon>登録</button>
+        <button *ngIf="notAddPage" mat-raised-button color="primary" class="margin-a-20" (click)="onUpdateButtonClick()" [disabled]="categoryForm.invalid"><mat-icon>edit</mat-icon>更新</button>
       </span> 
     </mat-card-footer>
 </mat-card>

--- a/src/app/category/component/form/form.component.html
+++ b/src/app/category/component/form/form.component.html
@@ -3,37 +3,28 @@
         <form [formGroup]="categoryForm" class="form-size">
             <p>
                 <mat-form-field appearance="outline" class="input-full-width">
-                  <mat-label>タイトル</mat-label>
-                  <input matInput placeholder="何かタイトル" formControlName="title">
-                  <mat-error *ngIf="categoryForm.controls['title'].hasError('required')">
-                    タイトルは<strong>必須</strong>です
+                  <mat-label>カテゴリ名</mat-label>
+                  <input matInput placeholder="何かタイトル" formControlName="name">
+                  <mat-error *ngIf="categoryForm.controls['name'].hasError('required')">
+                    カテゴリ名は<strong>必須</strong>です
                   </mat-error>
                 </mat-form-field>
             </p>
             <p>
               <mat-form-field appearance="outline" class="input-full-width">
-                <mat-label>カテゴリ※後でSelectBoxに変更する</mat-label>
-                <input matInput placeholder="カテゴリ※後でSelectBoxに変更する" formControlName="categoryId">
-                <mat-error *ngIf="categoryForm.controls['categoryId'].hasError('required')">
-                  カテゴリは<strong>必須</strong>です
+                <mat-label>slug</mat-label>
+                <input matInput placeholder="カテゴリ※後でSelectBoxに変更する" formControlName="slug">
+                <mat-error *ngIf="categoryForm.controls['slug'].hasError('required')">
+                  slugは<strong>英数字のみ</strong>で<strong>必須</strong>です
                 </mat-error>
               </mat-form-field>
             </p>
             <p>
-                <mat-form-field appearance="outline" class="textarea-full-width">
-                  <mat-label>本文</mat-label>
-                  <textarea rows="5" matInput placeholder="何か本文" formControlName="body" class="textarea-wrap"></textarea>
-                  <mat-error *ngIf="categoryForm.controls['body'].hasError('required')">
-                    本文は<strong>必須</strong>です
-                  </mat-error>
-                </mat-form-field>
-            </p>
-            <p>
                 <mat-form-field appearance="outline" class="input-full-width">
-                    <mat-label>ステータス※後でSelectBoxに変更する</mat-label>
-                    <input matInput placeholder="ステータス※後でSelectBoxに変更する" formControlName="state">
-                    <mat-error *ngIf="categoryForm.controls['state'].hasError('required')">
-                      ステータスは<strong>必須</strong>です
+                    <mat-label>色※後でSelectBoxに変更する</mat-label>
+                    <input type="number" matInput placeholder="色※後でSelectBoxに変更する" formControlName="color">
+                    <mat-error *ngIf="categoryForm.controls['color'].hasError('required')">
+                      色は<strong>必須</strong>です
                     </mat-error>
                 </mat-form-field>
             </p>

--- a/src/app/category/component/form/form.component.html
+++ b/src/app/category/component/form/form.component.html
@@ -32,7 +32,7 @@
     </mat-card-content>
     <mat-card-footer>
       <span class="float-left">
-        <button mat-raised-button color="warn" class="margin-a-20" (click)="onDeleteButtonClick()" ><mat-icon>delete</mat-icon>削除</button>
+        <button *ngIf="notAddPage" mat-raised-button color="warn" class="margin-a-20" (click)="onDeleteButtonClick()" ><mat-icon>delete</mat-icon>削除</button>
       </span> 
       <span> </span>
       <span class="float-right">

--- a/src/app/category/component/form/form.component.scss
+++ b/src/app/category/component/form/form.component.scss
@@ -1,3 +1,7 @@
+@use '@angular/material' as mat;
+.card-form-elevation{
+    @include mat.elevation(3);
+}
 .margin-a-20{
     margin: 20px;
 }

--- a/src/app/category/component/form/form.component.spec.ts
+++ b/src/app/category/component/form/form.component.spec.ts
@@ -1,18 +1,18 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
-import { FormComponent } from './form.component';
+import { CategoryFormComponent } from './form.component';
 
-describe('FormComponent', () => {
-  let component: FormComponent;
-  let fixture: ComponentFixture<FormComponent>;
+describe('CategoryFormComponent', () => {
+  let component: CategoryFormComponent;
+  let fixture: ComponentFixture<CategoryFormComponent>;
 
   beforeEach(async () => {
     await TestBed.configureTestingModule({
-      declarations: [ FormComponent ]
+      declarations: [ CategoryFormComponent ]
     })
     .compileComponents();
 
-    fixture = TestBed.createComponent(FormComponent);
+    fixture = TestBed.createComponent(CategoryFormComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();
   });

--- a/src/app/common/dialog/dialog.component.html
+++ b/src/app/common/dialog/dialog.component.html
@@ -3,6 +3,6 @@
   <p>削除してもいいですか？</p>
 </div>
 <div mat-dialog-actions>
-  <button class="float-left" mat-raised-button [mat-dialog-close]="false">戻る</button>
-  <button class="float-right" mat-raised-button color="warn"  cdkFocusInitial [mat-dialog-close]="true">削除</button>
+  <button class="float-left" mat-raised-button [mat-dialog-close]="false"><mat-icon>undo</mat-icon>戻る</button>
+  <button class="float-right" mat-raised-button color="warn"  cdkFocusInitial [mat-dialog-close]="true"><mat-icon>check_circle</mat-icon>実行</button>
 </div>

--- a/src/app/models/todo.ts
+++ b/src/app/models/todo.ts
@@ -6,4 +6,6 @@ export interface Todo {
     state: number;
     createdAt?:string;
     updatedAt?:string;
+    categoryName?:string;
+    categoryColor?:string;
   }

--- a/src/app/todo/component/card/card.component.html
+++ b/src/app/todo/component/card/card.component.html
@@ -2,8 +2,8 @@
     <a class="card-link" [routerLink]="['/todo/show', item.id ]"></a>
     <mat-card-header>
         <span class="category"><mat-card-title>{{item.id}}</mat-card-title></span>
-        <span class="category"><mat-card-title>{{item.categoryId}} {{item.title}}</mat-card-title></span>
-        <span class="category"><mat-chip-listbox><mat-chip-option color="{{getTaskStatusColorList(item.state)}}" class="card-chip" selected disabled>{{getStatusName(item.state)}}</mat-chip-option></mat-chip-listbox></span>
+        <span class="category"><mat-card-title><span class="card-chip category {{cateoryColorClass(item.categoryColor)}}" >{{item.categoryName}}</span>{{item.title}}</mat-card-title></span>
+        <span class="category"><mat-chip-listbox><mat-chip-option class="card-chip {{todoStatusColorClass(item.state)}}" disabled>{{getStatusName(item.state)}}</mat-chip-option></mat-chip-listbox></span>
         <span class="spacer"></span> 
         <span>
             <mat-card-subtitle>作成日:{{getLocalTime(item.createdAt)}}</mat-card-subtitle>

--- a/src/app/todo/component/card/card.component.html
+++ b/src/app/todo/component/card/card.component.html
@@ -1,4 +1,4 @@
-<mat-card class="margin-a-20">
+<mat-card class="margin-a-20 card-form-elevation">
     <a class="card-link" [routerLink]="['/todo/show', item.id ]"></a>
     <mat-card-header>
         <span class="category"><mat-card-title>{{item.id}}</mat-card-title></span>

--- a/src/app/todo/component/card/card.component.scss
+++ b/src/app/todo/component/card/card.component.scss
@@ -1,3 +1,7 @@
+@use '@angular/material' as mat;
+.card-form-elevation{
+    @include mat.elevation(3);
+}
 .margin-a-20{
     margin: 20px;
 }

--- a/src/app/todo/component/card/card.component.scss
+++ b/src/app/todo/component/card/card.component.scss
@@ -19,3 +19,14 @@
     height: 20px;
     opacity: unset!important;
 }
+.card-chip-color-none {
+}
+.card-chip-color-todo {
+    background-color: #52cfcf!important;
+}
+.card-chip-color-progress {
+    background-color: #d9b8ff!important;
+}
+.card-chip-color-complete {
+    background-color: #e45cae!important;
+}

--- a/src/app/todo/component/card/card.component.ts
+++ b/src/app/todo/component/card/card.component.ts
@@ -18,11 +18,16 @@ export class TodoCardComponent {
       updatedAt: ''
   }
   @Input() status:Status[] = []
-  taskStatusColorList:any =[
-    "primary",
-    "accent",
-    "warn"
+  todoStatusColorClassList:any =[
+    "card-chip-color-todo",
+    "card-chip-color-progress",
+    "card-chip-color-complete"
   ]
+  categoryColorClassList:any ={
+    "info":"card-chip-color-todo",
+    "warn":"card-chip-color-progress",
+    "danger":"card-chip-color-complete"
+  }
   constructor(private sanitizer: DomSanitizer) {}
   getBrEscape(text:string){
     return text.replace(/\\r\\n/g, '\r\n');
@@ -42,7 +47,14 @@ export class TodoCardComponent {
       return ''
     }
   }
-  getTaskStatusColorList(state:number){
-    return this.taskStatusColorList[state]
+  todoStatusColorClass(state:number){
+    return this.todoStatusColorClassList[state]
+  }
+  cateoryColorClass(colorName?:string){
+    if(typeof colorName === 'string'){
+      return this.categoryColorClassList[colorName]
+    }else{
+      return 'card-chip-color-none'
+    }
   }
 }

--- a/src/app/todo/component/form/form.component.html
+++ b/src/app/todo/component/form/form.component.html
@@ -1,4 +1,4 @@
-<mat-card class="margin-a-20">
+<mat-card class="margin-a-20 card-form-elevation">
     <mat-card-content>
         <form [formGroup]="todoForm" class="form-size">
             <p>
@@ -41,12 +41,12 @@
     </mat-card-content>
     <mat-card-footer>
       <span class="float-left">
-        <button mat-raised-button color="warn" class="margin-a-20" (click)="onDeleteButtonClick()" >削除</button>
+        <button mat-raised-button color="warn" class="margin-a-20" (click)="onDeleteButtonClick()" ><mat-icon>delete</mat-icon>削除</button>
       </span> 
       <span> </span>
       <span class="float-right">
-        <button *ngIf="!notAddPage" mat-raised-button color="primary" class="margin-a-20" (click)="onAddButtonClick()" [disabled]="todoForm.invalid">登録</button>
-        <button *ngIf="notAddPage" mat-raised-button color="primary" class="margin-a-20" (click)="onUpdateButtonClick()" [disabled]="todoForm.invalid">更新</button>
+        <button *ngIf="!notAddPage" mat-raised-button color="primary" class="margin-a-20" (click)="onAddButtonClick()" [disabled]="todoForm.invalid"><mat-icon>playlist_add</mat-icon>登録</button>
+        <button *ngIf="notAddPage" mat-raised-button color="primary" class="margin-a-20" (click)="onUpdateButtonClick()" [disabled]="todoForm.invalid"><mat-icon>edit</mat-icon>更新</button>
       </span> 
     </mat-card-footer>
 </mat-card>

--- a/src/app/todo/component/form/form.component.html
+++ b/src/app/todo/component/form/form.component.html
@@ -41,7 +41,7 @@
     </mat-card-content>
     <mat-card-footer>
       <span class="float-left">
-        <button mat-raised-button color="warn" class="margin-a-20" (click)="onDeleteButtonClick()" ><mat-icon>delete</mat-icon>削除</button>
+        <button *ngIf="notAddPage" mat-raised-button color="warn" class="margin-a-20" (click)="onDeleteButtonClick()" ><mat-icon>delete</mat-icon>削除</button>
       </span> 
       <span> </span>
       <span class="float-right">

--- a/src/app/todo/component/form/form.component.scss
+++ b/src/app/todo/component/form/form.component.scss
@@ -1,3 +1,7 @@
+@use '@angular/material' as mat;
+.card-form-elevation{
+    @include mat.elevation(3);
+}
 .margin-a-20{
     margin: 20px;
 }

--- a/src/app/todo/todo-add/todo-add.component.html
+++ b/src/app/todo/todo-add/todo-add.component.html
@@ -1,7 +1,7 @@
-<mat-toolbar class="margin-a-20" style="width:auto;">
+<mat-toolbar  class="margin-a-20 app-bar"  style="width:auto;">
     <a mat-icon-button routerLink="/todo">
         <mat-icon>arrow_back_ios_new</mat-icon>
     </a>
     <span>Todo追加</span>
 </mat-toolbar>
-<todo-form></todo-form>
+<todo-form ></todo-form>

--- a/src/app/todo/todo-add/todo-add.component.html
+++ b/src/app/todo/todo-add/todo-add.component.html
@@ -4,8 +4,4 @@
     </a>
     <span>Todo追加</span>
 </mat-toolbar>
-<<<<<<< HEAD
-<todo-form ></todo-form>
-=======
 <todo-form [path]="'add'"></todo-form>
->>>>>>> origin/main

--- a/src/app/todo/todo-add/todo-add.component.scss
+++ b/src/app/todo/todo-add/todo-add.component.scss
@@ -1,3 +1,10 @@
+@use '@angular/material' as mat;
+.app-bar{
+    @include mat.elevation(5);
+}
+.card-form-elevation{
+    @include mat.elevation(3);
+}
 .margin-a-20{
     margin: 20px;
 }

--- a/src/app/todo/todo-edit/todo-edit.component.html
+++ b/src/app/todo/todo-edit/todo-edit.component.html
@@ -1,4 +1,4 @@
-<mat-toolbar class="margin-a-20" style="width:auto;">
+<mat-toolbar  class="margin-a-20 app-bar"  style="width:auto;">
     <a mat-icon-button routerLink="/todo">
         <mat-icon>arrow_back_ios_new</mat-icon>
     </a>

--- a/src/app/todo/todo-edit/todo-edit.component.scss
+++ b/src/app/todo/todo-edit/todo-edit.component.scss
@@ -1,3 +1,7 @@
+@use '@angular/material' as mat;
+.app-bar{
+    @include mat.elevation(5);
+}
 .margin-a-20{
     margin: 20px;
 }

--- a/src/app/todo/todo-list/todo-list.component.html
+++ b/src/app/todo/todo-list/todo-list.component.html
@@ -1,6 +1,6 @@
-<mat-toolbar class="margin-a-20" style="width:auto;">
+<mat-toolbar class="margin-a-20 app-bar" style="width:auto;">
     <span>Todo一覧</span>
     <span class="spacer"></span> 
-    <a mat-flat-button color="primary" routerLink="/todo/add"><mat-icon>add_task</mat-icon>Todo追加</a>
+    <a mat-flat-button color="primary" routerLink="/todo/add"><mat-icon>playlist_add</mat-icon>Todo追加</a>
 </mat-toolbar>
-<todo-card *ngFor="let todo of todoList" [item]="todo" [status]="statusList"></todo-card>
+<todo-card class="card-elevation" *ngFor="let todo of todoList" [item]="todo" [status]="statusList"></todo-card>

--- a/src/app/todo/todo-list/todo-list.component.scss
+++ b/src/app/todo/todo-list/todo-list.component.scss
@@ -1,3 +1,7 @@
+@use '@angular/material' as mat;
+.app-bar{
+    @include mat.elevation(5);
+}
 .margin-a-20{
     margin: 20px;
 }
@@ -6,6 +10,9 @@
 }
 .category{
     margin-right: 20px;
+}
+.card-elevation{
+    @include mat.elevation(3);
 }
 .card-link{
     position: absolute;


### PR DESCRIPTION
# 対応

- カテゴリ登録/更新/削除画面を実装
- Material Designに則って、デザインにElevationを追加
- 画面遷移、機能実行ボタンについて、Material Design Iconを追加
- Todo,Category登録画面で、削除ボタンが表示されていた問題を修正

# イメージ
##Todo一覧

![image](https://user-images.githubusercontent.com/117155914/204239145-5ead46fe-1be6-4630-a147-5666e66e4376.png)


## Todo登録

![image](https://user-images.githubusercontent.com/117155914/204239233-f926a745-068b-4f3b-844e-4d87d464ab99.png)


## Todo更新

![image](https://user-images.githubusercontent.com/117155914/204239347-ae356fc1-f000-42ce-b39c-8905d860dbcf.png)

## Todo削除

![image](https://user-images.githubusercontent.com/117155914/204239461-b21298c2-f836-4d26-a343-2b1918320b17.png)


## Category登録

![image](https://user-images.githubusercontent.com/117155914/204238725-891beca8-618c-47d2-b118-0dd9f4ade6f6.png)

### バリデーション
![image](https://user-images.githubusercontent.com/117155914/204238795-e5135dc1-dfe7-4c6c-9acc-a0e072a48954.png)

## Category更新

![image](https://user-images.githubusercontent.com/117155914/204238962-e5678e83-8f0f-4eb1-a9c3-d45d7eebcec1.png)


## Category削除

※Todo削除と同じなので割愛


